### PR TITLE
Remove codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,4 @@ jobs:
           go-version: 1.17
 
       - name: Test
-        run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        run: go test -race -v ./...


### PR DESCRIPTION
Most of our test coverage comes from our e2e test, which isn't reported via codecov so it's not very helpful.